### PR TITLE
apns_production APNs 是否生产环境

### DIFF
--- a/options.go
+++ b/options.go
@@ -4,7 +4,7 @@ type Options struct {
 	SendNo            int                          `json:"sendno,omitempty"`              //推送序号
 	TimeToLive        int                          `json:"time_to_live,omitempty"`        //离线消息保留时长(秒)
 	OverrideMsgId     int                          `json:"override_msg_id,omitempty"`     //要覆盖的消息 ID
-	ApnsProduction    bool                         `json:"apns_production,omitempty"`     //APNs 是否生产环境
+	ApnsProduction    bool                         `json:"apns_production"`               //APNs 是否生产环境
 	ApnsCollapseId    string                       `json:"apns_collapse_id,omitempty"`    //更新 iOS 通知的标识符
 	BigPushDuration   int                          `json:"big_push_duration,omitempty"`   //定速推送时长(分钟)
 	ThirdPartyChannel map[string]ThirdPartyOptions `json:"third_party_channel,omitempty"` //推送请求下发通道


### PR DESCRIPTION
该字段仅对 iOS 的 Notification 有效，如果不指定则为推送生产环境。注意：JPush 服务端 SDK 默认设置为推送 “开发环境”。 true：表示推送生产环境。
false：表示推送开发环境。